### PR TITLE
Added dot symbol

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1909,6 +1909,6 @@ class BaseHtml
     public static function getInputId($model, $attribute)
     {
         $name = strtolower(static::getInputName($model, $attribute));
-        return str_replace(['[]', '][', '[', ']', ' '], ['', '-', '-', '', '-'], $name);
+        return str_replace(['[]', '][', '[', ']', ' ', '.'], ['', '-', '-', '', '-', '-'], $name);
     }
 }


### PR DESCRIPTION
When you use attributes of the model with dots in it's names, you get wrong id for html field.

Example when you need names with dots is when you use relations withing gridview
https://github.com/yiisoft/yii2/blob/master/docs/guide/output-data-widgets.md#working-with-model-relations